### PR TITLE
Handle cases where Impact could be different than Impacts listed in impactList object

### DIFF
--- a/src/Components/PresentationalComponents/ImpactBadge/ImpactBadge.js
+++ b/src/Components/PresentationalComponents/ImpactBadge/ImpactBadge.js
@@ -39,41 +39,39 @@ class ImpactBadge extends React.Component {
             Low: {
                 title: 'Low',
                 color: this.colorList.default
-            },
-            NotSet: {
-                title: 'Unknown',
-                color: this.colorList.default
             }
         };
     }
 
     getColoredBadgeByImpact(impact) {
         const iconSize = this.props.size || 'md';
-        let icon;
+        let badge;
 
-        if (this.props.impact !== 'NotSet') {
-            icon = <SecurityIcon size={iconSize} color={this.impactList[impact].color} />;
+        if (Object.keys(this.impactList).includes(impact)) {
+            badge = {
+                icon: <SecurityIcon size={iconSize} color={this.impactList[impact].color} />,
+                title: this.impactList[impact].title
+            };
         } else {
-            icon = <QuestionIcon size={iconSize} color={this.impactList[impact].color} />;
+            badge = {
+                icon: <QuestionIcon size={iconSize} color={this.colorList.default} />,
+                title: 'Unknown'
+            };
         }
 
-        return icon;
+        return badge;
     }
 
     render() {
+        const badge = this.getColoredBadgeByImpact(this.props.impact);
         return (
             <React.Fragment>
                 {this.props.hasTooltip === true ? (
-                    <Tooltip
-                        position="right"
-                        content={
-                            <div>{this.impactList[this.props.impact].title}</div>
-                        }
-                    >
-                        {this.getColoredBadgeByImpact(this.props.impact)}
+                    <Tooltip position="right" content={<div>Impact: {badge.title}</div>}>
+                        {badge.icon}
                     </Tooltip>
                 ) : (
-                    <span>{this.getColoredBadgeByImpact(this.props.impact)}</span>
+                    <span>{badge.icon}</span>
                 )}
             </React.Fragment>
         );


### PR DESCRIPTION
These code changes handle cases where Impact could be different than those listed in impactList - in this case the Impact should be question-mark with grey color.
ie. if prop has no value, it would crash on `this.impactList[this.props.impact]` as such index does not exist in the list.